### PR TITLE
Prevent wrapping in minimap buffer

### DIFF
--- a/autoload/minimap.py
+++ b/autoload/minimap.py
@@ -54,6 +54,8 @@ def showminimap():
         vim.command(":setlocal buftype=nofile bufhidden=wipe noswapfile nobuflisted")
         # make ensure our buffer is uncluttered
         vim.command(":setlocal nonumber norelativenumber nolist")
+        #make sure the buffer doesn't wrap.
+        vim.command(":setlocal nowrap")
 
         # Properly close the minimap when quitting VIM (ie, when minimap is the last remaining window
         vim.command(":autocmd! WinEnter <buffer> if winnr('$') == 1|q|endif")


### PR DESCRIPTION
When wrap is on and showbreak is enabled the minimap buffer looks terrible. To see what I mean add `set wrap` and `set showbreak=....` (That's four periods or dots) to your vimrc, then open vim and minimap. If it doesn't look terrible, add the following autocmd to your vimrc and restart vim: `autocmd! VimEnter,BufRead * Minimap`
